### PR TITLE
Typecast and comment correction

### DIFF
--- a/examples/ez_switch_lib_interrupt.ino
+++ b/examples/ez_switch_lib_interrupt.ino
@@ -48,7 +48,7 @@ int     interrupt_pin =  2;  // external interrupt pin
 // 'my_switches' layout.
 // one row of data for each switch to be configured, as follows:
 // [][0] = switch type
-// [][1] = digital output pin connected to switch
+// [][1] = digital input pin the switch is wired to
 // [][2] = the switch_id provided by the add_switch function for the switch declared
 // [][3] = the circuit type connecting the switch, here the switches
 //         will have 10k ohm pull down resistors wired

--- a/ez_switch_lib.cpp
+++ b/ez_switch_lib.cpp
@@ -17,7 +17,7 @@
 Switches::Switches(byte max_switches)
 {
   // Establish the switch control structure (switches) of the size required
-  switches = malloc(sizeof(*switches) * max_switches);
+  switches = (switch_control *)malloc(sizeof(*switches) * max_switches);
   if (switches == NULL) {
     // malloc failure
     Serial.begin(9600);


### PR DESCRIPTION
Addressing issue #1 and another issue in the cpp file that did not typecast the `malloc` call to the `switch_control *` typedef. (Unsure whether this is really required, my compiler threw an error and this is how I fixed it)